### PR TITLE
gitignore: auto variables added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,9 @@ init-cfg.txt
 temp
 terraform.rc
 tmp
+# Auto variables
+terraform.tfvars
+terraform.tfvars.json
+*.auto.tfvars
+*.auto.tfvars.json
 


### PR DESCRIPTION
## Description

All auto added variables should not be part of the project.

## Motivation and Context

All non-default value should be provided by end-user 
